### PR TITLE
tests/: syscall to end main

### DIFF
--- a/tests/test_strlen.asm
+++ b/tests/test_strlen.asm
@@ -39,7 +39,9 @@ main:
 
         jr $ra
 
-        # TODO :: end main
+        # REVIEW :: end main
+        li $v0, 10
+        syscall
 
 EXIT_ERROR:
         li $v0, 4 # Print the error message

--- a/tests/test_strlen.asm
+++ b/tests/test_strlen.asm
@@ -39,8 +39,7 @@ main:
 
         jr $ra
 
-        # REVIEW :: end main
-        li $v0, 10
+        li $v0, 17
         syscall
 
 EXIT_ERROR:

--- a/tests/test_strlen.asm
+++ b/tests/test_strlen.asm
@@ -37,8 +37,7 @@ main:
         lw   $ra, 0($sp)
         addi $sp, $sp, 4
 
-        jr $ra
-
+        li $a0, 0
         li $v0, 17
         syscall
 

--- a/tests/tests_is_valid_phone_number.asm
+++ b/tests/tests_is_valid_phone_number.asm
@@ -38,8 +38,7 @@ main:
         lw   $ra, 0($sp)
         addi $sp, $sp, 4
 
-        jr $ra
-
+        li $a0, 0
         li $v0, 17
         syscall
 

--- a/tests/tests_is_valid_phone_number.asm
+++ b/tests/tests_is_valid_phone_number.asm
@@ -40,7 +40,9 @@ main:
 
         jr $ra
 
-        # TODO :: end main
+        # REVIEW :: end main
+        li $v0, 10
+        syscall
 
 EXIT_ERROR:
         li $v0, 4

--- a/tests/tests_is_valid_phone_number.asm
+++ b/tests/tests_is_valid_phone_number.asm
@@ -40,8 +40,7 @@ main:
 
         jr $ra
 
-        # REVIEW :: end main
-        li $v0, 10
+        li $v0, 17
         syscall
 
 EXIT_ERROR:


### PR DESCRIPTION
Review wether or not it is necessary to explicitely terminate the
program (by using the designated syscall [10]), in some cases, not doing
so ends up looping main the function infinitely.